### PR TITLE
Implement Namco mappers

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,9 +62,11 @@ jobs:
         components: rust-src, clippy
 
     - name: Install wasm-pack
-      run: |
-        curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-
+      uses: actions-rs/cargo@v1
+      with:
+        command: install
+        args: wasm-pack
+      
     - name: Build web
       run: |
         cd jgnes-web && ./build.sh

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Implemented:
   * Color Dreams unlicensed board
   * Bandai FCG-1 / FCG-2 / LZ93D50
     * The LZ93D50 variant that uses the Datach Joint ROM system is not implemented (iNES mapper 157)
+  * Namco 129 / 163
   * Jaleco JF-11 / JF-14
   * GxROM
   * BNROM
@@ -36,7 +37,7 @@ Not Implemented:
 * Cycle-accurate rendering effects of enabling rendering mid-scanline
 * DMC DMA cycle stealing and dummy reads, an obscure hardware quirk that affects very very few if any games
 * Color palette customization; the NES hardware directly outputs an NTSC video signal rather than RGB pixel grids, so any mapping from NES colors to RGB colors is an approximation at best
-* Lots of mappers, most notably Namco's custom mappers
+* Lots of more obscure cartridge boards
 * Fast forward or rewind
 * Support for PAL/EU releases (the processor timings are different compared to NTSC US/JP)
 * Support for any controller port peripherals (e.g. the Zapper)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Implemented:
   * Color Dreams unlicensed board
   * Bandai FCG-1 / FCG-2 / LZ93D50
     * The LZ93D50 variant that uses the Datach Joint ROM system is not implemented (iNES mapper 157)
-  * Namco 108 / 129 / 163, including 163 expansion audio
+  * Namco 108 / 129 / 163 / 175 / 340, including 163 expansion audio
   * NAMCOT-3425 / NAMCOT-3446 / NAMCOT-3453
   * Jaleco JF-11 / JF-14
   * GxROM

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Implemented:
   * Color Dreams unlicensed board
   * Bandai FCG-1 / FCG-2 / LZ93D50
     * The LZ93D50 variant that uses the Datach Joint ROM system is not implemented (iNES mapper 157)
-  * Namco 129 / 163
+  * Namco 108 / 129 / 163, including 163 expansion audio
+  * NAMCOT-3425 / NAMCOT-3446 / NAMCOT-3453
   * Jaleco JF-11 / JF-14
   * GxROM
   * BNROM

--- a/jgnes-core/src/bus/cartridge.rs
+++ b/jgnes-core/src/bus/cartridge.rs
@@ -543,13 +543,15 @@ pub(crate) fn from_ines_file(
             cartridge,
             data: Cnrom::new(header.chr_type, header.nametable_mirroring),
         }),
-        4 => Mapper::Mmc3(MapperImpl {
+        4 | 76 | 206 => Mapper::Mmc3(MapperImpl {
             cartridge,
             data: Mmc3::new(
                 header.chr_type,
                 header.prg_rom_size,
                 chr_size,
+                header.mapper_number,
                 header.sub_mapper_number,
+                header.nametable_mirroring,
                 header.has_four_screen_vram,
             ),
         }),

--- a/jgnes-core/src/bus/cartridge.rs
+++ b/jgnes-core/src/bus/cartridge.rs
@@ -333,6 +333,7 @@ impl Mapper {
     pub(crate) fn sample_audio(&self, mixed_apu_sample: f64) -> f64 {
         match self {
             Self::Mmc5(mmc5) => mmc5.sample_audio(mixed_apu_sample),
+            Self::Namco163(namco163) => namco163.sample_audio(mixed_apu_sample),
             Self::Sunsoft(sunsoft) => sunsoft.sample_audio(mixed_apu_sample),
             Self::Vrc6(vrc6) => vrc6.sample_audio(mixed_apu_sample),
             _ => mixed_apu_sample,

--- a/jgnes-core/src/bus/cartridge.rs
+++ b/jgnes-core/src/bus/cartridge.rs
@@ -543,7 +543,7 @@ pub(crate) fn from_ines_file(
             cartridge,
             data: Cnrom::new(header.chr_type, header.nametable_mirroring),
         }),
-        4 | 76 | 88 | 154 | 206 => Mapper::Mmc3(MapperImpl {
+        4 | 76 | 88 | 95 | 154 | 206 => Mapper::Mmc3(MapperImpl {
             cartridge,
             data: Mmc3::new(
                 header.chr_type,

--- a/jgnes-core/src/bus/cartridge.rs
+++ b/jgnes-core/src/bus/cartridge.rs
@@ -1,8 +1,8 @@
 mod mappers;
 
 use crate::bus::cartridge::mappers::{
-    Axrom, BandaiFcg, Bnrom, ChrType, Cnrom, Gxrom, Mmc1, Mmc2, Mmc3, Mmc5, NametableMirroring,
-    Nrom, Sunsoft, Uxrom, Vrc4, Vrc6, Vrc7,
+    Axrom, BandaiFcg, Bnrom, ChrType, Cnrom, Gxrom, Mmc1, Mmc2, Mmc3, Mmc5, Namco163,
+    NametableMirroring, Nrom, Sunsoft, Uxrom, Vrc4, Vrc6, Vrc7,
 };
 use bincode::de::{BorrowDecoder, Decoder};
 use bincode::enc::Encoder;
@@ -136,6 +136,7 @@ pub(crate) enum Mapper {
     Mmc2(MapperImpl<Mmc2>),
     Mmc3(MapperImpl<Mmc3>),
     Mmc5(MapperImpl<Mmc5>),
+    Namco163(MapperImpl<Namco163>),
     Nrom(MapperImpl<Nrom>),
     Sunsoft(MapperImpl<Sunsoft>),
     Uxrom(MapperImpl<Uxrom>),
@@ -157,6 +158,7 @@ impl Mapper {
             Self::Mmc2(mmc2) => mmc2.name(),
             Self::Mmc3(mmc3) => mmc3.name(),
             Self::Mmc5(..) => "MMC5",
+            Self::Namco163(..) => "Namco 163",
             Self::Nrom(..) => "NROM",
             Self::Sunsoft(..) => "Sunsoft",
             Self::Uxrom(uxrom) => uxrom.name(),
@@ -206,6 +208,9 @@ impl Mapper {
             Self::Mmc5(mmc5) => {
                 mmc5.tick_cpu();
             }
+            Self::Namco163(namco163) => {
+                namco163.tick_cpu();
+            }
             Self::Sunsoft(sunsoft) => {
                 sunsoft.tick_cpu();
             }
@@ -228,6 +233,7 @@ impl Mapper {
             Self::BandaiFcg(bandai_fcg) => bandai_fcg.interrupt_flag(),
             Self::Mmc3(mmc3) => mmc3.interrupt_flag(),
             Self::Mmc5(mmc5) => mmc5.interrupt_flag(),
+            Self::Namco163(namco163) => namco163.interrupt_flag(),
             Self::Sunsoft(sunsoft) => sunsoft.interrupt_flag(),
             Self::Vrc4(vrc4) => vrc4.interrupt_flag(),
             Self::Vrc6(vrc6) => vrc6.interrupt_flag(),
@@ -257,11 +263,20 @@ impl Mapper {
     /// Return whether the board's writable memory (if any) has been written to since the last time
     /// this method was called.
     pub(crate) fn get_and_clear_ram_dirty_bit(&mut self) -> bool {
-        if let Mapper::BandaiFcg(mapper) = self {
-            // Bandai FCG chips can have EEPROM - prefer that memory if present
-            if mapper.get_and_clear_eeprom_dirty_bit() {
-                return true;
+        match self {
+            Mapper::BandaiFcg(mapper) => {
+                if mapper.get_and_clear_eeprom_dirty_bit() {
+                    return true;
+                }
             }
+            Mapper::Namco163(mapper) => {
+                if mapper.has_battery_backed_internal_ram()
+                    && mapper.get_and_clear_internal_ram_dirty_bit()
+                {
+                    return true;
+                }
+            }
+            _ => {}
         }
 
         match_each_variant!(self, mapper => {
@@ -274,21 +289,36 @@ impl Mapper {
     /// Return the board's writable memory as a slice. This will be an empty slice if the board
     /// has no PRG RAM or EEPROM.
     pub(crate) fn get_prg_ram(&self) -> &[u8] {
-        if let Mapper::BandaiFcg(mapper) = self {
-            // Bandai FCG chips can have EEPROM - prefer that memory if present
-            if let Some(eeprom) = mapper.eeprom() {
-                return eeprom;
+        match self {
+            Mapper::BandaiFcg(mapper) => {
+                if let Some(eeprom) = mapper.eeprom() {
+                    return eeprom;
+                }
             }
+            Mapper::Namco163(mapper) => {
+                if mapper.has_battery_backed_internal_ram() {
+                    return mapper.get_internal_ram();
+                }
+            }
+            _ => {}
         }
 
         match_each_variant!(self, mapper => &mapper.cartridge.prg_ram)
     }
 
     pub(crate) fn has_persistent_ram(&self) -> bool {
-        if let Mapper::BandaiFcg(mapper) = self {
-            if mapper.eeprom().is_some() {
-                return true;
+        match self {
+            Mapper::BandaiFcg(mapper) => {
+                if mapper.eeprom().is_some() {
+                    return true;
+                }
             }
+            Mapper::Namco163(mapper) => {
+                if mapper.has_battery_backed_internal_ram() {
+                    return true;
+                }
+            }
+            _ => {}
         }
 
         !self.get_prg_ram().is_empty()
@@ -548,6 +578,16 @@ pub(crate) fn from_ines_file(
                 header.chr_type,
                 header.prg_ram_size,
                 sav_bytes.as_ref(),
+            ),
+        }),
+        19 => Mapper::Namco163(MapperImpl {
+            cartridge,
+            data: Namco163::new(
+                header.sub_mapper_number,
+                header.chr_type,
+                header.has_battery,
+                header.prg_ram_size,
+                sav_bytes,
             ),
         }),
         21 | 22 | 23 | 25 => Mapper::Vrc4(MapperImpl {

--- a/jgnes-core/src/bus/cartridge.rs
+++ b/jgnes-core/src/bus/cartridge.rs
@@ -543,7 +543,7 @@ pub(crate) fn from_ines_file(
             cartridge,
             data: Cnrom::new(header.chr_type, header.nametable_mirroring),
         }),
-        4 | 76 | 206 => Mapper::Mmc3(MapperImpl {
+        4 | 76 | 88 | 206 => Mapper::Mmc3(MapperImpl {
             cartridge,
             data: Mmc3::new(
                 header.chr_type,

--- a/jgnes-core/src/bus/cartridge.rs
+++ b/jgnes-core/src/bus/cartridge.rs
@@ -1,7 +1,7 @@
 mod mappers;
 
 use crate::bus::cartridge::mappers::{
-    Axrom, BandaiFcg, Bnrom, ChrType, Cnrom, Gxrom, Mmc1, Mmc2, Mmc3, Mmc5, Namco163,
+    Axrom, BandaiFcg, Bnrom, ChrType, Cnrom, Gxrom, Mmc1, Mmc2, Mmc3, Mmc5, Namco163, Namco175,
     NametableMirroring, Nrom, Sunsoft, Uxrom, Vrc4, Vrc6, Vrc7,
 };
 use bincode::de::{BorrowDecoder, Decoder};
@@ -137,6 +137,7 @@ pub(crate) enum Mapper {
     Mmc3(MapperImpl<Mmc3>),
     Mmc5(MapperImpl<Mmc5>),
     Namco163(MapperImpl<Namco163>),
+    Namco175(MapperImpl<Namco175>),
     Nrom(MapperImpl<Nrom>),
     Sunsoft(MapperImpl<Sunsoft>),
     Uxrom(MapperImpl<Uxrom>),
@@ -159,6 +160,7 @@ impl Mapper {
             Self::Mmc3(mmc3) => mmc3.name(),
             Self::Mmc5(..) => "MMC5",
             Self::Namco163(..) => "Namco 163",
+            Self::Namco175(..) => "Namco 175",
             Self::Nrom(..) => "NROM",
             Self::Sunsoft(..) => "Sunsoft",
             Self::Uxrom(uxrom) => uxrom.name(),
@@ -614,6 +616,14 @@ pub(crate) fn from_ines_file(
         85 => Mapper::Vrc7(MapperImpl {
             cartridge,
             data: Vrc7::new(header.sub_mapper_number, header.chr_type),
+        }),
+        210 => Mapper::Namco175(MapperImpl {
+            cartridge,
+            data: Namco175::new(
+                header.sub_mapper_number,
+                header.chr_type,
+                header.nametable_mirroring,
+            ),
         }),
         _ => {
             return Err(CartridgeFileError::UnsupportedMapper {

--- a/jgnes-core/src/bus/cartridge.rs
+++ b/jgnes-core/src/bus/cartridge.rs
@@ -543,7 +543,7 @@ pub(crate) fn from_ines_file(
             cartridge,
             data: Cnrom::new(header.chr_type, header.nametable_mirroring),
         }),
-        4 | 76 | 88 | 206 => Mapper::Mmc3(MapperImpl {
+        4 | 76 | 88 | 154 | 206 => Mapper::Mmc3(MapperImpl {
             cartridge,
             data: Mmc3::new(
                 header.chr_type,

--- a/jgnes-core/src/bus/cartridge/mappers.rs
+++ b/jgnes-core/src/bus/cartridge/mappers.rs
@@ -4,6 +4,7 @@ mod mmc1;
 mod mmc2;
 mod mmc3;
 mod mmc5;
+mod namco163;
 mod nrom;
 mod sunsoft;
 
@@ -17,6 +18,7 @@ pub(crate) use mmc1::Mmc1;
 pub(crate) use mmc2::Mmc2;
 pub(crate) use mmc3::Mmc3;
 pub(crate) use mmc5::Mmc5;
+pub(crate) use namco163::Namco163;
 pub(crate) use nrom::{Axrom, Bnrom, Cnrom, Gxrom, Nrom, Uxrom};
 pub(crate) use sunsoft::Sunsoft;
 

--- a/jgnes-core/src/bus/cartridge/mappers.rs
+++ b/jgnes-core/src/bus/cartridge/mappers.rs
@@ -5,6 +5,7 @@ mod mmc2;
 mod mmc3;
 mod mmc5;
 mod namco163;
+mod namco175;
 mod nrom;
 mod sunsoft;
 
@@ -19,6 +20,7 @@ pub(crate) use mmc2::Mmc2;
 pub(crate) use mmc3::Mmc3;
 pub(crate) use mmc5::Mmc5;
 pub(crate) use namco163::Namco163;
+pub(crate) use namco175::Namco175;
 pub(crate) use nrom::{Axrom, Bnrom, Cnrom, Gxrom, Nrom, Uxrom};
 pub(crate) use sunsoft::Sunsoft;
 

--- a/jgnes-core/src/bus/cartridge/mappers/mmc3.rs
+++ b/jgnes-core/src/bus/cartridge/mappers/mmc3.rs
@@ -1,4 +1,10 @@
 //! Code for the MMC3 and MMC6 boards (iNES mapper 4).
+//!
+//! This module also contains code for some other boards that are extremely similar to MMC3:
+//! * Namco 108 (iNES mapper 206)
+//! * Namco 108 with 128KB CHR ROM (iNES mapper 88)
+//! * NAMCOT-3446 (iNES mapper 76)
+//! * NAMCOT-3453 (iNES mapper 154)
 
 use crate::bus;
 use crate::bus::cartridge::mappers::{BankSizeKb, ChrType, NametableMirroring, PpuMapResult};

--- a/jgnes-core/src/bus/cartridge/mappers/namco163.rs
+++ b/jgnes-core/src/bus/cartridge/mappers/namco163.rs
@@ -348,7 +348,7 @@ impl MapperImpl<Namco163> {
             0xF800..=0xFFFF => {
                 // This register doubles as both PRG RAM write protection and the internal RAM address
                 self.data.ram_writes_enabled = value & 0xF0 == 0x40;
-                for bit in 0..3 {
+                for bit in 0..=3 {
                     self.data.ram_window_writes_enabled[bit as usize] = !value.bit(bit);
                 }
 

--- a/jgnes-core/src/bus/cartridge/mappers/namco163.rs
+++ b/jgnes-core/src/bus/cartridge/mappers/namco163.rs
@@ -1,4 +1,5 @@
-/// Code for the Namco 129 and Namco 163 boards (iNES mapper 19).
+//! Code for the Namco 129 and Namco 163 boards (iNES mapper 19).
+
 use crate::bus;
 use crate::bus::cartridge::mappers::{BankSizeKb, ChrType, PpuMapResult};
 use crate::bus::cartridge::MapperImpl;

--- a/jgnes-core/src/bus/cartridge/mappers/namco163.rs
+++ b/jgnes-core/src/bus/cartridge/mappers/namco163.rs
@@ -187,7 +187,18 @@ impl Namco163AudioUnit {
     }
 
     fn sample(&self) -> f64 {
-        self.channels[self.current_channel as usize].current_output
+        if self.enabled_channel_count <= 6 {
+            self.channels[self.current_channel as usize].current_output
+        } else {
+            // Special case 7-8 enabled channels because an accurate implementation sounds horrible
+            // without a very expensive low-pass filter
+            let channel_sum = (0..=7)
+                .rev()
+                .take(self.enabled_channel_count as usize)
+                .map(|i| self.channels[i].current_output)
+                .sum::<f64>();
+            channel_sum / f64::from(self.enabled_channel_count)
+        }
     }
 }
 

--- a/jgnes-core/src/bus/cartridge/mappers/namco163.rs
+++ b/jgnes-core/src/bus/cartridge/mappers/namco163.rs
@@ -1,3 +1,4 @@
+/// Code for the Namco 129 and Namco 163 boards (iNES mapper 19).
 use crate::bus;
 use crate::bus::cartridge::mappers::{BankSizeKb, ChrType, PpuMapResult};
 use crate::bus::cartridge::MapperImpl;

--- a/jgnes-core/src/bus/cartridge/mappers/namco163.rs
+++ b/jgnes-core/src/bus/cartridge/mappers/namco163.rs
@@ -1,0 +1,276 @@
+use crate::bus;
+use crate::bus::cartridge::mappers::{BankSizeKb, ChrType, PpuMapResult};
+use crate::bus::cartridge::MapperImpl;
+use crate::num::GetBit;
+use bincode::{Decode, Encode};
+
+#[derive(Debug, Clone, Encode, Decode)]
+struct IrqCounter {
+    enabled: bool,
+    counter: u16,
+}
+
+// 15-bit counter
+const MAX_IRQ_COUNTER: u16 = 0x7FFF;
+
+impl IrqCounter {
+    fn new() -> Self {
+        Self {
+            enabled: false,
+            counter: 0,
+        }
+    }
+
+    fn get_counter_low_bits(&self) -> u8 {
+        self.counter as u8
+    }
+
+    fn get_counter_high_bits(&self) -> u8 {
+        (u8::from(self.enabled) << 7) | ((self.counter >> 8) as u8)
+    }
+
+    fn update_counter_low_bits(&mut self, value: u8) {
+        self.counter = (self.counter & 0xFF00) | u16::from(value);
+    }
+
+    fn update_counter_high_bits(&mut self, value: u8) {
+        self.enabled = value.bit(7);
+        self.counter = (self.counter & 0x00FF) | (u16::from(value & 0x7F) << 8);
+    }
+
+    fn tick_cpu(&mut self) {
+        if self.enabled && self.counter < MAX_IRQ_COUNTER {
+            self.counter += 1;
+        }
+    }
+
+    fn interrupt_flag(&self) -> bool {
+        self.enabled && self.counter == MAX_IRQ_COUNTER
+    }
+}
+
+#[derive(Debug, Clone, Encode, Decode)]
+struct Namco163Audio {
+    enabled: bool,
+}
+
+impl Namco163Audio {
+    fn new() -> Self {
+        Self { enabled: false }
+    }
+}
+
+#[derive(Debug, Clone, Encode, Decode)]
+pub(crate) struct Namco163 {
+    chr_type: ChrType,
+    internal_ram: [u8; 128],
+    internal_ram_addr: u8,
+    internal_ram_auto_increment: bool,
+    internal_ram_dirty_bit: bool,
+    prg_banks: [u8; 3],
+    pattern_table_chr_banks: [u8; 8],
+    nametable_chr_banks: [u8; 4],
+    vram_chr_banks_enabled: [bool; 2],
+    ram_writes_enabled: bool,
+    ram_window_writes_enabled: [bool; 4],
+    irq: IrqCounter,
+    audio: Namco163Audio,
+}
+
+impl Namco163 {
+    pub(crate) fn new(
+        _sub_mapper_number: u8,
+        chr_type: ChrType,
+        has_battery: bool,
+        prg_ram_len: u32,
+        sav_bytes: Option<Vec<u8>>,
+    ) -> Self {
+        let mut internal_ram = [0; 128];
+
+        if has_battery && prg_ram_len == 0 {
+            if let Some(sav_bytes) = sav_bytes {
+                if sav_bytes.len() == internal_ram.len() {
+                    internal_ram.copy_from_slice(&sav_bytes);
+                }
+            }
+        }
+
+        Self {
+            chr_type,
+            internal_ram,
+            internal_ram_addr: 0,
+            internal_ram_auto_increment: false,
+            internal_ram_dirty_bit: true,
+            prg_banks: [0; 3],
+            pattern_table_chr_banks: [0; 8],
+            nametable_chr_banks: [0; 4],
+            vram_chr_banks_enabled: [false; 2],
+            ram_writes_enabled: false,
+            ram_window_writes_enabled: [false; 4],
+            irq: IrqCounter::new(),
+            audio: Namco163Audio::new(),
+        }
+    }
+}
+
+impl MapperImpl<Namco163> {
+    pub(crate) fn read_cpu_address(&mut self, address: u16) -> u8 {
+        match address {
+            0x0000..=0x401F => panic!("invalid CPU map address: {address:04X}"),
+            0x4020..=0x47FF => bus::cpu_open_bus(address),
+            0x4800..=0x4FFF => {
+                let byte = self.data.internal_ram[self.data.internal_ram_addr as usize];
+                if self.data.internal_ram_auto_increment {
+                    self.data.internal_ram_addr = (self.data.internal_ram_addr + 1) & 0x7F;
+                }
+                byte
+            }
+            0x5000..=0x57FF => self.data.irq.get_counter_low_bits(),
+            0x5800..=0x5FFF => self.data.irq.get_counter_high_bits(),
+            0x6000..=0x7FFF => {
+                if !self.cartridge.prg_ram.is_empty() {
+                    self.cartridge.get_prg_ram((address & 0x1FFF).into())
+                } else {
+                    bus::cpu_open_bus(address)
+                }
+            }
+            0x8000..=0xDFFF => {
+                // $8000-$9FFF to bank index 0
+                // $A000-$BFFF to bank index 1
+                // $C000-$DFFF to bank index 2
+                let bank_index = (address & 0x7FFF) / 0x2000;
+                let bank_number = self.data.prg_banks[bank_index as usize];
+                let prg_rom_addr = BankSizeKb::Eight.to_absolute_address(bank_number, address);
+                self.cartridge.get_prg_rom(prg_rom_addr)
+            }
+            0xE000..=0xFFFF => {
+                let prg_rom_addr = BankSizeKb::Eight
+                    .to_absolute_address_last_bank(self.cartridge.prg_rom.len() as u32, address);
+                self.cartridge.get_prg_rom(prg_rom_addr)
+            }
+        }
+    }
+
+    pub(crate) fn write_cpu_address(&mut self, address: u16, value: u8) {
+        match address {
+            0x0000..=0x401F => panic!("invalid CPU map address: {address:04X}"),
+            0x4020..=0x47FF => {}
+            0x4800..=0x4FFF => {
+                if self.data.ram_writes_enabled {
+                    self.data.internal_ram[self.data.internal_ram_addr as usize] = value;
+                    self.data.internal_ram_dirty_bit = true;
+
+                    if self.data.internal_ram_auto_increment {
+                        self.data.internal_ram_addr = (self.data.internal_ram_addr + 1) & 0x7F;
+                    }
+                }
+            }
+            0x5000..=0x57FF => {
+                self.data.irq.update_counter_low_bits(value);
+            }
+            0x5800..=0x5FFF => {
+                self.data.irq.update_counter_high_bits(value);
+            }
+            0x6000..=0x7FFF => {
+                if !self.cartridge.prg_ram.is_empty() && self.data.ram_writes_enabled {
+                    let prg_ram_addr = address & 0x1FFF;
+                    let window_index = prg_ram_addr / 0x0800;
+                    if self.data.ram_window_writes_enabled[window_index as usize] {
+                        self.cartridge.set_prg_ram(prg_ram_addr.into(), value);
+                    }
+                }
+            }
+            0x8000..=0xBFFF => {
+                let bank_index = (address & 0x7FFF) / 0x0800;
+                self.data.pattern_table_chr_banks[bank_index as usize] = value;
+            }
+            0xC000..=0xDFFF => {
+                let bank_index = (address & 0x3FFF) / 0x0800;
+                self.data.nametable_chr_banks[bank_index as usize] = value;
+            }
+            0xE000..=0xE7FF => {
+                self.data.audio.enabled = !value.bit(6);
+                self.data.prg_banks[0] = value & 0x3F;
+            }
+            0xE800..=0xEFFF => {
+                self.data.vram_chr_banks_enabled[1] = !value.bit(7);
+                self.data.vram_chr_banks_enabled[0] = !value.bit(6);
+                self.data.prg_banks[1] = value & 0x3F;
+            }
+            0xF000..=0xF7FF => {
+                self.data.prg_banks[2] = value & 0x3F;
+            }
+            0xF800..=0xFFFF => {
+                self.data.ram_writes_enabled = value & 0xF0 == 0x40;
+                for bit in 0..3 {
+                    self.data.ram_window_writes_enabled[bit as usize] = !value.bit(bit);
+                }
+            }
+        }
+    }
+
+    fn map_ppu_address(&self, address: u16) -> PpuMapResult {
+        match address {
+            0x0000..=0x1FFF => {
+                let bank_index = address / 0x0400;
+                let bank_number = self.data.pattern_table_chr_banks[bank_index as usize];
+                let pattern_table_index = address / 0x1000;
+                if bank_number >= 0xE0
+                    && self.data.vram_chr_banks_enabled[pattern_table_index as usize]
+                {
+                    let vram_bank = u16::from(bank_number & 0x01);
+                    PpuMapResult::Vram((vram_bank * 0x0400) | (address & 0x03FF))
+                } else {
+                    let chr_addr = BankSizeKb::One.to_absolute_address(bank_number, address);
+                    self.data.chr_type.to_map_result(chr_addr)
+                }
+            }
+            0x2000..=0x3EFF => {
+                let relative_addr = address & 0x0FFF;
+                let bank_index = relative_addr / 0x0400;
+                let bank_number = self.data.nametable_chr_banks[bank_index as usize];
+                if bank_number >= 0xE0 {
+                    let vram_bank = u16::from(bank_number & 0x01);
+                    PpuMapResult::Vram((vram_bank * 0x0400) | (address & 0x03FF))
+                } else {
+                    let chr_addr = BankSizeKb::One.to_absolute_address(bank_number, address);
+                    self.data.chr_type.to_map_result(chr_addr)
+                }
+            }
+            0x3F00..=0xFFFF => {
+                panic!("invalid PPU map address: {address:04X}")
+            }
+        }
+    }
+
+    pub(crate) fn read_ppu_address(&self, address: u16, vram: &[u8; 2048]) -> u8 {
+        self.map_ppu_address(address).read(&self.cartridge, vram)
+    }
+
+    pub(crate) fn write_ppu_address(&mut self, address: u16, value: u8, vram: &mut [u8; 2048]) {
+        self.map_ppu_address(address)
+            .write(value, &mut self.cartridge, vram);
+    }
+
+    pub(crate) fn tick_cpu(&mut self) {
+        self.data.irq.tick_cpu();
+    }
+
+    pub(crate) fn interrupt_flag(&self) -> bool {
+        self.data.irq.interrupt_flag()
+    }
+
+    pub(crate) fn has_battery_backed_internal_ram(&self) -> bool {
+        self.cartridge.has_ram_battery && self.cartridge.prg_ram.is_empty()
+    }
+
+    pub(crate) fn get_and_clear_internal_ram_dirty_bit(&mut self) -> bool {
+        let dirty_bit = self.data.internal_ram_dirty_bit;
+        self.data.internal_ram_dirty_bit = false;
+        dirty_bit
+    }
+
+    pub(crate) fn get_internal_ram(&self) -> &[u8; 128] {
+        &self.data.internal_ram
+    }
+}

--- a/jgnes-core/src/bus/cartridge/mappers/namco163.rs
+++ b/jgnes-core/src/bus/cartridge/mappers/namco163.rs
@@ -192,10 +192,12 @@ impl Namco163AudioUnit {
         } else {
             // Special case 7-8 enabled channels because an accurate implementation sounds horrible
             // without a very expensive low-pass filter
-            let channel_sum = (0..=7)
+            let channel_sum = self
+                .channels
+                .iter()
                 .rev()
                 .take(self.enabled_channel_count as usize)
-                .map(|i| self.channels[i].current_output)
+                .map(|channel| channel.current_output)
                 .sum::<f64>();
             channel_sum / f64::from(self.enabled_channel_count)
         }

--- a/jgnes-core/src/bus/cartridge/mappers/namco163.rs
+++ b/jgnes-core/src/bus/cartridge/mappers/namco163.rs
@@ -187,10 +187,10 @@ impl Namco163AudioUnit {
     }
 
     fn sample(&self) -> f64 {
-        if self.enabled_channel_count <= 6 {
+        if self.enabled_channel_count < 6 {
             self.channels[self.current_channel as usize].current_output
         } else {
-            // Special case 7-8 enabled channels because an accurate implementation sounds horrible
+            // Special case 6-8 enabled channels because an accurate implementation sounds horrible
             // without a very expensive low-pass filter
             let channel_sum = self
                 .channels

--- a/jgnes-core/src/bus/cartridge/mappers/namco175.rs
+++ b/jgnes-core/src/bus/cartridge/mappers/namco175.rs
@@ -1,8 +1,9 @@
+//! Code for the Namco 175 and Namco 340 boards (iNES mapper 210).
+
 use crate::bus;
 use crate::bus::cartridge::mappers::{BankSizeKb, ChrType, NametableMirroring, PpuMapResult};
 use crate::bus::cartridge::MapperImpl;
 use crate::num::GetBit;
-/// Code for the Namco 175 and Namco 340 boards (iNES mapper 210).
 use bincode::{Decode, Encode};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Encode, Decode)]

--- a/jgnes-core/src/bus/cartridge/mappers/namco175.rs
+++ b/jgnes-core/src/bus/cartridge/mappers/namco175.rs
@@ -1,0 +1,139 @@
+use crate::bus;
+use crate::bus::cartridge::mappers::{BankSizeKb, ChrType, NametableMirroring, PpuMapResult};
+use crate::bus::cartridge::MapperImpl;
+use crate::num::GetBit;
+/// Code for the Namco 175 and Namco 340 boards (iNES mapper 210).
+use bincode::{Decode, Encode};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Encode, Decode)]
+enum Variant {
+    Namco175,
+    Namco340,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Encode, Decode)]
+pub(crate) struct Namco175 {
+    variant: Variant,
+    chr_type: ChrType,
+    nametable_mirroring: NametableMirroring,
+    prg_banks: [u8; 3],
+    chr_banks: [u8; 8],
+    ram_enabled: bool,
+}
+
+impl Namco175 {
+    pub(crate) fn new(
+        sub_mapper_number: u8,
+        chr_type: ChrType,
+        nametable_mirroring: NametableMirroring,
+    ) -> Self {
+        let variant = match sub_mapper_number {
+            1 => Variant::Namco175,
+            2 => Variant::Namco340,
+            _ => Variant::Unknown,
+        };
+
+        log::info!("Namco 175 variant: {variant:?}");
+
+        Self {
+            variant,
+            chr_type,
+            nametable_mirroring,
+            prg_banks: [0; 3],
+            chr_banks: [0; 8],
+            ram_enabled: false,
+        }
+    }
+}
+
+impl MapperImpl<Namco175> {
+    pub(crate) fn read_cpu_address(&self, address: u16) -> u8 {
+        match address {
+            0x0000..=0x401F => panic!("invalid CPU map address: {address:04X}"),
+            0x4020..=0x5FFF => bus::cpu_open_bus(address),
+            0x6000..=0x7FFF => {
+                if self.data.ram_enabled && !self.cartridge.prg_ram.is_empty() {
+                    self.cartridge.get_prg_ram((address & 0x1FFF).into())
+                } else {
+                    bus::cpu_open_bus(address)
+                }
+            }
+            0x8000..=0xDFFF => {
+                let bank_index = (address & 0x7FFF) / 0x2000;
+                let bank_number = self.data.prg_banks[bank_index as usize];
+                let prg_rom_addr = BankSizeKb::Eight.to_absolute_address(bank_number, address);
+                self.cartridge.get_prg_rom(prg_rom_addr)
+            }
+            0xE000..=0xFFFF => {
+                let prg_rom_addr = BankSizeKb::Eight
+                    .to_absolute_address_last_bank(self.cartridge.prg_rom.len() as u32, address);
+                self.cartridge.get_prg_rom(prg_rom_addr)
+            }
+        }
+    }
+
+    pub(crate) fn write_cpu_address(&mut self, address: u16, value: u8) {
+        match address {
+            0x0000..=0x401F => panic!("invalid CPU map address: {address:04X}"),
+            0x6000..=0x7FFF => {
+                if self.data.ram_enabled && !self.cartridge.prg_ram.is_empty() {
+                    self.cartridge.set_prg_ram((address & 0x1FFF).into(), value);
+                }
+            }
+            0x8000..=0xBFFF => {
+                let bank_index = (address & 0x7FFF) / 0x0800;
+                self.data.chr_banks[bank_index as usize] = value;
+            }
+            0xC000..=0xC7FF => {
+                if matches!(self.data.variant, Variant::Namco175 | Variant::Unknown) {
+                    self.data.ram_enabled = value.bit(0);
+                }
+            }
+            0xE000..=0xE7FF => {
+                self.data.prg_banks[0] = value & 0x3F;
+
+                if matches!(self.data.variant, Variant::Namco340 | Variant::Unknown) {
+                    self.data.nametable_mirroring = match value & 0xC0 {
+                        0x00 => NametableMirroring::SingleScreenBank0,
+                        0x40 => NametableMirroring::Vertical,
+                        0x80 => NametableMirroring::SingleScreenBank1,
+                        0xC0 => NametableMirroring::Horizontal,
+                        _ => unreachable!("value & 0xC0 should always be 0x00/0x40/0x80/0xC0"),
+                    };
+                }
+            }
+            0xE800..=0xEFFF => {
+                self.data.prg_banks[1] = value & 0x3F;
+            }
+            0xF000..=0xF7FF => {
+                self.data.prg_banks[2] = value & 0x3F;
+            }
+            _ => {}
+        }
+    }
+
+    fn map_ppu_address(&self, address: u16) -> PpuMapResult {
+        match address {
+            0x0000..=0x1FFF => {
+                let bank_index = address / 0x0400;
+                let bank_number = self.data.chr_banks[bank_index as usize];
+                let chr_addr = BankSizeKb::One.to_absolute_address(bank_number, address);
+                self.data.chr_type.to_map_result(chr_addr)
+            }
+            0x2000..=0x3EFF => {
+                PpuMapResult::Vram(self.data.nametable_mirroring.map_to_vram(address))
+            }
+            0x3F00..=0xFFFF => panic!("invalid PPU map result: {address:04X}"),
+        }
+    }
+
+    pub(crate) fn read_ppu_address(&self, address: u16, vram: &[u8; 2048]) -> u8 {
+        self.map_ppu_address(address).read(&self.cartridge, vram)
+    }
+
+    pub(crate) fn write_ppu_address(&mut self, address: u16, value: u8, vram: &mut [u8; 2048]) {
+        self.map_ppu_address(address)
+            .write(value, &mut self.cartridge, vram);
+    }
+}

--- a/jgnes-gui/src/romlist.rs
+++ b/jgnes-gui/src/romlist.rs
@@ -136,6 +136,7 @@ fn mapper_name(mapper_number: u16, sub_mapper_number: u8) -> &'static str {
         85 => "Konami VRC7",
         88 | 206 => "Namco 108",
         140 => "Jaleco JF-14",
+        154 => "NAMCOT-3453",
         210 => match sub_mapper_number {
             2 => "Namco 340",
             _ => "Namco 175",

--- a/jgnes-gui/src/romlist.rs
+++ b/jgnes-gui/src/romlist.rs
@@ -132,8 +132,10 @@ fn mapper_name(mapper_number: u16, sub_mapper_number: u8) -> &'static str {
         66 => "GxROM",
         69 => "Sunsoft FME-7",
         71 => "Codemasters",
+        76 => "NAMCOT-3446",
         85 => "Konami VRC7",
         140 => "Jaleco JF-14",
+        206 => "Namco 108",
         210 => match sub_mapper_number {
             2 => "Namco 340",
             _ => "Namco 175",

--- a/jgnes-gui/src/romlist.rs
+++ b/jgnes-gui/src/romlist.rs
@@ -135,6 +135,7 @@ fn mapper_name(mapper_number: u16, sub_mapper_number: u8) -> &'static str {
         76 => "NAMCOT-3446",
         85 => "Konami VRC7",
         88 | 206 => "Namco 108",
+        95 => "NAMCOT-3425",
         140 => "Jaleco JF-14",
         154 => "NAMCOT-3453",
         210 => match sub_mapper_number {

--- a/jgnes-gui/src/romlist.rs
+++ b/jgnes-gui/src/romlist.rs
@@ -118,6 +118,7 @@ fn mapper_name(mapper_number: u16, sub_mapper_number: u8) -> &'static str {
         10 => "MMC4",
         11 => "Color Dreams",
         16 | 153 | 159 => "Bandai FCG",
+        19 => "Namco 163",
         21 | 23 | 25 => match (mapper_number, sub_mapper_number) {
             (23 | 25, 3) => "VRC2",
             _ => "VRC4",

--- a/jgnes-gui/src/romlist.rs
+++ b/jgnes-gui/src/romlist.rs
@@ -120,11 +120,11 @@ fn mapper_name(mapper_number: u16, sub_mapper_number: u8) -> &'static str {
         16 | 153 | 159 => "Bandai FCG",
         19 => "Namco 163",
         21 | 23 | 25 => match (mapper_number, sub_mapper_number) {
-            (23 | 25, 3) => "VRC2",
-            _ => "VRC4",
+            (23 | 25, 3) => "Konami VRC2",
+            _ => "Konami VRC4",
         },
-        22 => "VRC2",
-        24 | 26 => "VRC6",
+        22 => "Konami VRC2",
+        24 | 26 => "Konami VRC6",
         34 => match sub_mapper_number {
             1 => "NINA-001",
             _ => "BNROM",
@@ -132,8 +132,12 @@ fn mapper_name(mapper_number: u16, sub_mapper_number: u8) -> &'static str {
         66 => "GxROM",
         69 => "Sunsoft FME-7",
         71 => "Codemasters",
-        85 => "VRC7",
+        85 => "Konami VRC7",
         140 => "Jaleco JF-14",
+        210 => match sub_mapper_number {
+            2 => "Namco 340",
+            _ => "Namco 175",
+        },
         _ => "(Unknown)",
     }
 }

--- a/jgnes-gui/src/romlist.rs
+++ b/jgnes-gui/src/romlist.rs
@@ -134,8 +134,8 @@ fn mapper_name(mapper_number: u16, sub_mapper_number: u8) -> &'static str {
         71 => "Codemasters",
         76 => "NAMCOT-3446",
         85 => "Konami VRC7",
+        88 | 206 => "Namco 108",
         140 => "Jaleco JF-14",
-        206 => "Namco 108",
         210 => match sub_mapper_number {
             2 => "Namco 340",
             _ => "Namco 175",


### PR DESCRIPTION
Implemented:
* iNES mapper 19 (Namco 129 / 163): Used in a number of Japan-released games, most notably _Digital Devil Story: Megami Tensei II_
* iNES mapper 76 (NAMCOT-3446), used only in _Digital Devil Story: Megami Tensei_
* iNES mapper 88, a variant of mapper 206 used in 3 games: _Quinty_, _Namcot Mahjong 3_, and _Dragon Spirit: Aratanaru Densetsu_
* iNES mapper 95 (NAMCOT-3425), used only in _Dragon Buster_
* iNES mapper 154 (NAMCOT-3453), used only in _Devil Man_
* iNES mapper 206 (various Tengen/Namco boards), e.g. _Gauntlet_ and _Pac-Mania_
* NES mapper 210 (Namco 175 / 340), e.g. _Splatterhouse: Wanpaku Graffiti_