### PR TITLE
Implement PAL support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Add nightly toolchain
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: nightly
+        toolchain: nightly-2023-06-01
         components: rust-src, clippy
 
     - name: Install wasm-pack
@@ -67,11 +67,11 @@ jobs:
       
     - name: Build web
       run: |
-        cd jgnes-web && ./build.sh
+        cd jgnes-web && JGNES_WEB_TOOLCHAIN=nightly-2023-06-01 ./build.sh
 
     - name: Check warnings for web
       run: |
-        cd jgnes-web && cargo +nightly cranky --target wasm32-unknown-unknown -- -D warnings
+        cd jgnes-web && cargo +nightly-2023-06-01 cranky --target wasm32-unknown-unknown -- -D warnings
   linux-release:
     runs-on: ubuntu-latest
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1706,6 +1706,7 @@ dependencies = [
  "pollster",
  "sdl2",
  "serde",
+ "thiserror",
  "tinyvec",
  "windows 0.48.0",
 ]
@@ -1723,13 +1724,13 @@ dependencies = [
 name = "jgnes-renderer"
 version = "0.5.0"
 dependencies = [
- "anyhow",
  "bytemuck",
  "jgnes-core",
  "jgnes-proc-macros",
  "log",
  "raw-window-handle",
  "serde",
+ "thiserror",
  "wgpu",
 ]
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Implemented:
 * Save & load state
 * Fast forward with a configurable speed multiplier (very CPU-intensive at higher multipliers; my i5-1240P laptop maxes out between 5x and 6x speed)
 * Rewind
+* Support for both NTSC and PAL releases
 
 Not Implemented:
 * Unofficial CPU opcodes
@@ -40,7 +41,6 @@ Not Implemented:
 * DMC DMA cycle stealing and dummy reads, an obscure hardware quirk that affects very very few if any games
 * Color palette customization; the NES hardware directly outputs an NTSC video signal rather than RGB pixel grids, so any mapping from NES colors to RGB colors is an approximation at best
 * Lots of more obscure cartridge boards
-* Support for PAL/EU releases (the processor timings are different compared to NTSC US/JP)
 * Support for any controller port peripherals (e.g. the Zapper)
 
 ## Crate Structure

--- a/jgnes-cli/src/main.rs
+++ b/jgnes-cli/src/main.rs
@@ -51,6 +51,10 @@ struct CliArgs {
     #[arg(long, default_value_t)]
     forced_integer_height_scaling: bool,
 
+    /// Emulate PAL black border
+    #[arg(long, default_value_t)]
+    pal_black_border: bool,
+
     /// Disable audio sync
     #[arg(long = "no-audio-sync", default_value_t = true, action = clap::ArgAction::SetFalse)]
     sync_to_audio: bool,
@@ -126,6 +130,7 @@ fn main() -> anyhow::Result<()> {
         overscan,
         forced_integer_height_scaling: args.forced_integer_height_scaling,
         vsync_mode: args.vsync_mode,
+        pal_black_border: args.pal_black_border,
         sync_to_audio: args.sync_to_audio,
         silence_ultrasonic_triangle_output: args.silence_ultrasonic_triangle_output,
         fast_forward_multiplier: args.fast_forward_multiplier,

--- a/jgnes-cli/src/main.rs
+++ b/jgnes-cli/src/main.rs
@@ -43,7 +43,7 @@ struct CliArgs {
     #[arg(long, default_value_t = 3)]
     gpu_render_scale: u32,
 
-    /// Aspect ratio (Ntsc / SquarePixels / FourThree / Stretched)
+    /// Aspect ratio (Ntsc / Pal / SquarePixels / FourThree / Stretched)
     #[arg(long, default_value_t)]
     aspect_ratio: AspectRatio,
 

--- a/jgnes-cli/src/main.rs
+++ b/jgnes-cli/src/main.rs
@@ -111,7 +111,10 @@ fn main() -> anyhow::Result<()> {
     let gpu_filter_mode = match args.gpu_filter_type {
         GpuFilterType::NearestNeighbor => GpuFilterMode::NearestNeighbor,
         GpuFilterType::Linear => {
-            let render_scale = args.gpu_render_scale.try_into()?;
+            let render_scale = args
+                .gpu_render_scale
+                .try_into()
+                .expect("invalid GPU render scale");
             GpuFilterMode::Linear(render_scale)
         }
     };

--- a/jgnes-core/src/api.rs
+++ b/jgnes-core/src/api.rs
@@ -290,10 +290,7 @@ pub enum InitializationError<RenderError> {
     },
 }
 
-impl<R: Renderer, A: AudioPlayer, I: InputPoller, S: SaveWriter> Emulator<R, A, I, S>
-where
-    R::Err: Debug,
-{
+impl<R: Renderer, A: AudioPlayer, I: InputPoller, S: SaveWriter> Emulator<R, A, I, S> {
     /// Create a new emulator instance.
     ///
     /// # Errors
@@ -486,7 +483,10 @@ where
     ///
     /// `sav_bytes` will be used if set, otherwise PRG RAM will be moved from the existing Emulator.
     #[must_use]
-    pub fn hard_reset(self, sav_bytes: Option<Vec<u8>>) -> Self {
+    pub fn hard_reset(self, sav_bytes: Option<Vec<u8>>) -> Self
+    where
+        R::Err: Debug,
+    {
         let prg_ram = sav_bytes.unwrap_or_else(|| Vec::from(self.bus.mapper().get_prg_ram()));
         Self::create(
             self.raw_rom_bytes,

--- a/jgnes-core/src/api.rs
+++ b/jgnes-core/src/api.rs
@@ -1,6 +1,6 @@
 use crate::apu::ApuState;
 use crate::bus::cartridge::CartridgeFileError;
-use crate::bus::{cartridge, Bus, PpuBus};
+use crate::bus::{cartridge, Bus, PpuBus, TimingMode};
 use crate::cpu::{CpuError, CpuRegisters, CpuState};
 use crate::input::JoypadState;
 use crate::ppu::{FrameBuffer, PpuState};
@@ -8,9 +8,15 @@ use crate::serialize::SaveStateError;
 use crate::{apu, cpu, ppu, serialize};
 use std::cell::RefCell;
 use std::error::Error;
-use std::fmt::{Display, Formatter};
+use std::fmt::{Debug, Display, Formatter};
 use std::io;
 use std::rc::Rc;
+
+// The number of master clock ticks to run in one `Emulator::tick` call
+const PAL_MASTER_CLOCK_TICKS: u32 = 80;
+
+const PAL_CPU_DIVIDER: u32 = 16;
+const PAL_PPU_DIVIDER: u32 = 5;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct ColorEmphasis {
@@ -54,10 +60,10 @@ pub trait Renderer {
     /// The R/G/B color emphasis bits are included directly from the NES PPU. It is up to
     /// implementations to choose how to apply these.
     ///
-    /// Note that while the NES's internal resolution is 256x240, virtually no TVs displayed more
-    /// than 224 pixels vertically due to overscan, so just about every implementation will want to
-    /// remove the top 8 and bottom 8 rows of pixels to produce a 256x224 frame. Some games may look
-    /// better with even more overscan on certain sides of the frame.
+    /// Note that while the NES's internal resolution is 256x240, the visible vertical resolution
+    /// depends on whether the emulated console is running in NTSC mode or PAL mode. If in NTSC
+    /// mode, the renderer should display at most 224px vertically, removing the top 8 and bottom 8
+    /// rows of pixels. If in PAL mode, the renderer should display the full 240px.
     ///
     /// # Errors
     ///
@@ -68,6 +74,13 @@ pub trait Renderer {
         frame_buffer: &FrameBuffer,
         color_emphasis: ColorEmphasis,
     ) -> Result<(), Self::Err>;
+
+    /// Set the timing mode (NTSC/PAL). This will be called whenever a new ROM is loaded, although
+    /// renderers should default to NTSC if it is not called.
+    ///
+    /// Renderers need to be aware of timing mode because the visible screen height is different
+    /// between NTSC (224px) and PAL (240px), but the NES frame buffer is 256x240 in both cases.
+    fn set_timing_mode(&mut self, timing_mode: TimingMode) -> Result<(), Self::Err>;
 }
 
 impl<R: Renderer> Renderer for Rc<RefCell<R>> {
@@ -79,6 +92,10 @@ impl<R: Renderer> Renderer for Rc<RefCell<R>> {
         color_emphasis: ColorEmphasis,
     ) -> Result<(), Self::Err> {
         self.borrow_mut().render_frame(frame_buffer, color_emphasis)
+    }
+
+    fn set_timing_mode(&mut self, timing_mode: TimingMode) -> Result<(), Self::Err> {
+        self.borrow_mut().set_timing_mode(timing_mode)
     }
 }
 
@@ -240,7 +257,13 @@ pub enum TickEffect {
 pub type EmulationResult<RenderError, AudioError, SaveError> =
     Result<TickEffect, EmulationError<RenderError, AudioError, SaveError>>;
 
-impl<R: Renderer, A: AudioPlayer, I: InputPoller, S: SaveWriter> Emulator<R, A, I, S> {
+type UnitEmulationResult<RenderError, AudioError, SaveError> =
+    Result<(), EmulationError<RenderError, AudioError, SaveError>>;
+
+impl<R: Renderer, A: AudioPlayer, I: InputPoller, S: SaveWriter> Emulator<R, A, I, S>
+where
+    R::Err: Debug,
+{
     /// Create a new emulator instance.
     ///
     /// # Errors
@@ -250,18 +273,23 @@ impl<R: Renderer, A: AudioPlayer, I: InputPoller, S: SaveWriter> Emulator<R, A, 
     pub fn create(
         rom_bytes: Vec<u8>,
         sav_bytes: Option<Vec<u8>>,
-        renderer: R,
+        mut renderer: R,
         audio_player: A,
         input_poller: I,
         save_writer: S,
     ) -> Result<Self, CartridgeFileError> {
         let mapper = cartridge::from_ines_file(&rom_bytes, sav_bytes)?;
+        let timing_mode = mapper.timing_mode();
+
+        // TODO properly propagate errors
+        renderer.set_timing_mode(timing_mode).unwrap();
+
         let mut bus = Bus::from_cartridge(mapper);
 
         let cpu_registers = CpuRegisters::create(&mut bus.cpu());
         let cpu_state = CpuState::new(cpu_registers);
-        let ppu_state = PpuState::new();
-        let mut apu_state = ApuState::new();
+        let ppu_state = PpuState::new(timing_mode);
+        let mut apu_state = ApuState::new(timing_mode);
 
         init_apu(&mut apu_state, &mut bus);
 
@@ -278,7 +306,7 @@ impl<R: Renderer, A: AudioPlayer, I: InputPoller, S: SaveWriter> Emulator<R, A, 
         })
     }
 
-    /// Run the emulator for one CPU cycle / three PPU cycles.
+    /// Run the emulator for 1 CPU cycle / 3 PPU cycles (NTSC) or 5 CPU cycles / 16 PPU cycles (PAL).
     ///
     /// # Errors
     ///
@@ -288,32 +316,16 @@ impl<R: Renderer, A: AudioPlayer, I: InputPoller, S: SaveWriter> Emulator<R, A, 
     pub fn tick(&mut self, config: &EmulatorConfig) -> EmulationResult<R::Err, A::Err, S::Err> {
         let prev_in_vblank = self.ppu_state.in_vblank();
 
-        cpu::tick(
-            &mut self.cpu_state,
-            &mut self.bus.cpu(),
-            self.apu_state.is_active_cycle(),
-        )?;
-        apu::tick(&mut self.apu_state, &mut self.bus.cpu(), config);
-        ppu::tick(&mut self.ppu_state, &mut self.bus.ppu());
-        self.bus.tick();
-        self.bus.tick_cpu();
+        let timing_mode = self.bus.mapper().timing_mode();
 
-        self.bus.poll_interrupt_lines();
-
-        ppu::tick(&mut self.ppu_state, &mut self.bus.ppu());
-        self.bus.tick();
-
-        ppu::tick(&mut self.ppu_state, &mut self.bus.ppu());
-        self.bus.tick();
-
-        let audio_sample = {
-            let sample = self.apu_state.sample();
-            let sample = self.bus.mapper().sample_audio(sample);
-            self.apu_state.high_pass_filter(sample)
-        };
-        self.audio_player
-            .push_sample(audio_sample)
-            .map_err(EmulationError::Audio)?;
+        match timing_mode {
+            TimingMode::Ntsc => {
+                self.ntsc_tick(config)?;
+            }
+            TimingMode::Pal => {
+                self.pal_tick(config)?;
+            }
+        }
 
         if !prev_in_vblank && self.ppu_state.in_vblank() {
             let frame_buffer = self.ppu_state.frame_buffer();
@@ -340,6 +352,83 @@ impl<R: Renderer, A: AudioPlayer, I: InputPoller, S: SaveWriter> Emulator<R, A, 
         }
 
         Ok(TickEffect::None)
+    }
+
+    fn ntsc_tick(
+        &mut self,
+        config: &EmulatorConfig,
+    ) -> UnitEmulationResult<R::Err, A::Err, S::Err> {
+        cpu::tick(
+            &mut self.cpu_state,
+            &mut self.bus.cpu(),
+            self.apu_state.is_active_cycle(),
+        )?;
+        apu::tick(&mut self.apu_state, &mut self.bus.cpu(), config);
+        ppu::tick(&mut self.ppu_state, &mut self.bus.ppu());
+        self.bus.tick();
+        self.bus.tick_cpu();
+
+        self.bus.poll_interrupt_lines();
+
+        ppu::tick(&mut self.ppu_state, &mut self.bus.ppu());
+        self.bus.tick();
+
+        ppu::tick(&mut self.ppu_state, &mut self.bus.ppu());
+        self.bus.tick();
+
+        self.push_audio_sample()?;
+
+        Ok(())
+    }
+
+    fn pal_tick(&mut self, config: &EmulatorConfig) -> UnitEmulationResult<R::Err, A::Err, S::Err> {
+        // Both CPU and PPU tick on the first master clock cycle
+        cpu::tick(
+            &mut self.cpu_state,
+            &mut self.bus.cpu(),
+            self.apu_state.is_active_cycle(),
+        )?;
+        apu::tick(&mut self.apu_state, &mut self.bus.cpu(), config);
+        ppu::tick(&mut self.ppu_state, &mut self.bus.ppu());
+        self.bus.tick();
+        self.bus.tick_cpu();
+
+        self.bus.poll_interrupt_lines();
+
+        self.push_audio_sample()?;
+
+        for i in 1..PAL_MASTER_CLOCK_TICKS {
+            if i % PAL_CPU_DIVIDER == 0 {
+                cpu::tick(
+                    &mut self.cpu_state,
+                    &mut self.bus.cpu(),
+                    self.apu_state.is_active_cycle(),
+                )?;
+                apu::tick(&mut self.apu_state, &mut self.bus.cpu(), config);
+                self.bus.tick();
+                self.bus.tick_cpu();
+
+                self.bus.poll_interrupt_lines();
+
+                self.push_audio_sample()?;
+            } else if i % PAL_PPU_DIVIDER == 0 {
+                ppu::tick(&mut self.ppu_state, &mut self.bus.ppu());
+                self.bus.tick();
+            }
+        }
+
+        Ok(())
+    }
+
+    fn push_audio_sample(&mut self) -> UnitEmulationResult<R::Err, A::Err, S::Err> {
+        let audio_sample = {
+            let sample = self.apu_state.sample();
+            let sample = self.bus.mapper().sample_audio(sample);
+            self.apu_state.high_pass_filter(sample)
+        };
+        self.audio_player
+            .push_sample(audio_sample)
+            .map_err(EmulationError::Audio)
     }
 
     /// Press the (emulated) reset button.

--- a/jgnes-core/src/api.rs
+++ b/jgnes-core/src/api.rs
@@ -240,6 +240,8 @@ impl<R: Error + 'static, A: Error + 'static, S: Error + 'static> Error for Emula
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct EmulatorConfig {
+    /// If true, add a black border over the top scanline, the leftmost 2 columns, and the rightmost 2 columns
+    pub pal_black_border: bool,
     /// If true, silence the triangle wave channel when it is outputting a wave at ultrasonic frequency
     pub silence_ultrasonic_triangle_output: bool,
 }
@@ -357,6 +359,10 @@ impl<R: Renderer, A: AudioPlayer, I: InputPoller, S: SaveWriter> Emulator<R, A, 
         }
 
         if !prev_in_vblank && self.ppu_state.in_vblank() {
+            if config.pal_black_border {
+                ppu::render_pal_black_border(&mut self.ppu_state);
+            }
+
             let frame_buffer = self.ppu_state.frame_buffer();
             let color_emphasis = ColorEmphasis::get_current(&self.bus.ppu());
 

--- a/jgnes-core/src/apu.rs
+++ b/jgnes-core/src/apu.rs
@@ -190,7 +190,6 @@ impl FrameCounter {
 
 #[derive(Debug, Clone, Encode, Decode)]
 pub struct ApuState {
-    timing_mode: TimingMode,
     pulse_channel_1: PulseChannel,
     pulse_channel_2: PulseChannel,
     triangle_channel: TriangleChannel,
@@ -204,7 +203,6 @@ pub struct ApuState {
 impl ApuState {
     pub fn new(timing_mode: TimingMode) -> Self {
         Self {
-            timing_mode,
             pulse_channel_1: PulseChannel::new_channel_1(SweepStatus::Enabled),
             pulse_channel_2: PulseChannel::new_channel_2(SweepStatus::Enabled),
             triangle_channel: TriangleChannel::new(),

--- a/jgnes-core/src/apu.rs
+++ b/jgnes-core/src/apu.rs
@@ -22,7 +22,7 @@ use crate::apu::dmc::DeltaModulationChannel;
 use crate::apu::noise::NoiseChannel;
 use crate::apu::pulse::{PulseChannel, SweepStatus};
 use crate::apu::triangle::TriangleChannel;
-use crate::bus::{CpuBus, IoRegister, IrqSource};
+use crate::bus::{CpuBus, IoRegister, IrqSource, TimingMode};
 use crate::num::GetBit;
 use crate::EmulatorConfig;
 use bincode::{Decode, Encode};
@@ -126,6 +126,7 @@ impl FrameCounter {
 
 #[derive(Debug, Clone, Encode, Decode)]
 pub struct ApuState {
+    timing_mode: TimingMode,
     pulse_channel_1: PulseChannel,
     pulse_channel_2: PulseChannel,
     triangle_channel: TriangleChannel,
@@ -137,8 +138,9 @@ pub struct ApuState {
 }
 
 impl ApuState {
-    pub fn new() -> Self {
+    pub fn new(timing_mode: TimingMode) -> Self {
         Self {
+            timing_mode,
             pulse_channel_1: PulseChannel::new_channel_1(SweepStatus::Enabled),
             pulse_channel_2: PulseChannel::new_channel_2(SweepStatus::Enabled),
             triangle_channel: TriangleChannel::new(),

--- a/jgnes-core/src/bus/cartridge/mappers/mmc5.rs
+++ b/jgnes-core/src/bus/cartridge/mappers/mmc5.rs
@@ -5,7 +5,7 @@ use crate::apu::FrameCounter;
 use crate::bus::cartridge::mappers::{BankSizeKb, CpuMapResult};
 use crate::bus::cartridge::{Cartridge, MapperImpl};
 use crate::num::GetBit;
-use crate::{apu, bus};
+use crate::{apu, bus, TimingMode};
 use bincode::{Decode, Encode};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Encode, Decode)]
@@ -590,7 +590,7 @@ impl Mmc5 {
             pulse_channel_1: PulseChannel::new_channel_1(SweepStatus::Disabled),
             pulse_channel_2: PulseChannel::new_channel_2(SweepStatus::Disabled),
             pcm_channel: PcmChannel::new(),
-            frame_counter: FrameCounter::new(),
+            frame_counter: FrameCounter::new(TimingMode::Ntsc),
             ram_writes_enabled_1: false,
             ram_writes_enabled_2: false,
         }

--- a/jgnes-core/src/cpu.rs
+++ b/jgnes-core/src/cpu.rs
@@ -100,6 +100,8 @@ pub struct CpuRegisters {
 }
 
 impl CpuRegisters {
+    /// Create a new `CpuRegisters` value with the PC pointing to the address at the cartridge's
+    /// RESET vector.
     pub fn create(bus: &mut CpuBus<'_>) -> Self {
         let pc_lsb = bus.read_address(bus::CPU_RESET_VECTOR);
         let pc_msb = bus.read_address(bus::CPU_RESET_VECTOR + 1);

--- a/jgnes-core/src/lib.rs
+++ b/jgnes-core/src/lib.rs
@@ -14,5 +14,6 @@ pub use api::{
     AudioPlayer, ColorEmphasis, EmulationError, EmulationResult, EmulationState, Emulator,
     EmulatorConfig, InputPoller, Renderer, SaveWriter, TickEffect,
 };
+pub use bus::TimingMode;
 pub use input::JoypadState;
-pub use ppu::{FrameBuffer, SCREEN_HEIGHT, SCREEN_WIDTH, VISIBLE_SCREEN_HEIGHT};
+pub use ppu::{FrameBuffer, SCREEN_HEIGHT, SCREEN_WIDTH};

--- a/jgnes-core/src/ppu.rs
+++ b/jgnes-core/src/ppu.rs
@@ -41,6 +41,7 @@ const PAL_PRE_RENDER_SCANLINE: u16 = 311;
 pub type FrameBuffer = [[u8; SCREEN_WIDTH as usize]; SCREEN_HEIGHT as usize];
 
 impl TimingMode {
+    #[must_use]
     pub const fn visible_screen_height(self) -> u16 {
         match self {
             Self::Ntsc => NTSC_VISIBLE_SCREEN_HEIGHT,

--- a/jgnes-core/src/ppu.rs
+++ b/jgnes-core/src/ppu.rs
@@ -38,6 +38,8 @@ const PAL_VBLANK_SCANLINES: RangeInclusive<u16> = 241..=310;
 const PAL_ALL_IDLE_SCANLINES: RangeInclusive<u16> = 240..=310;
 const PAL_PRE_RENDER_SCANLINE: u16 = 311;
 
+const BLACK_NES_COLOR: u8 = 0x0F;
+
 pub type FrameBuffer = [[u8; SCREEN_WIDTH as usize]; SCREEN_HEIGHT as usize];
 
 impl TimingMode {
@@ -312,8 +314,7 @@ impl PpuState {
             scanline: timing_mode.pre_render_scanline(),
             dot: 0,
             odd_frame: false,
-            // 0x0F == Black
-            rendering_disabled_backdrop_color: Some(0x0F),
+            rendering_disabled_backdrop_color: Some(BLACK_NES_COLOR),
             pending_sprite_0_hit: false,
         }
     }
@@ -333,6 +334,25 @@ impl PpuState {
     /// colors that are appropriate for display.
     pub fn frame_buffer(&self) -> &FrameBuffer {
         &self.frame_buffer
+    }
+}
+
+pub fn render_pal_black_border(state: &mut PpuState) {
+    // Clear top scanline
+    for value in state.frame_buffer[0].iter_mut() {
+        *value = BLACK_NES_COLOR;
+    }
+
+    // Clear leftmost two columns and rightmost two columns
+    for col in [
+        0,
+        1,
+        (SCREEN_WIDTH - 2) as usize,
+        (SCREEN_WIDTH - 1) as usize,
+    ] {
+        for row in 1..SCREEN_HEIGHT as usize {
+            state.frame_buffer[row][col] = BLACK_NES_COLOR;
+        }
     }
 }
 

--- a/jgnes-gui/src/app.rs
+++ b/jgnes-gui/src/app.rs
@@ -916,6 +916,8 @@ impl App {
                     ui.horizontal(|ui| {
                         ui.radio_value(&mut self.config.aspect_ratio, AspectRatio::Ntsc, "NTSC")
                             .on_hover_text("8:7 pixel aspect ratio, 64:49 screen aspect ratio");
+                        ui.radio_value(&mut self.config.aspect_ratio, AspectRatio::Pal, "PAL")
+                            .on_hover_text("11:8 pixel aspect ratio, 11:7 screen aspect ratio");
                         ui.radio_value(&mut self.config.aspect_ratio, AspectRatio::SquarePixels, "Square pixels")
                             .on_hover_text("1:1 pixel aspect ratio, 8:7 screen aspect ratio");
                         ui.radio_value(&mut self.config.aspect_ratio, AspectRatio::FourThree, "4:3")

--- a/jgnes-gui/src/app.rs
+++ b/jgnes-gui/src/app.rs
@@ -917,7 +917,7 @@ impl App {
                         ui.radio_value(&mut self.config.aspect_ratio, AspectRatio::Ntsc, "NTSC")
                             .on_hover_text("8:7 pixel aspect ratio, 64:49 screen aspect ratio");
                         ui.radio_value(&mut self.config.aspect_ratio, AspectRatio::Pal, "PAL")
-                            .on_hover_text("11:8 pixel aspect ratio, 11:7 screen aspect ratio");
+                            .on_hover_text("11:8 pixel aspect ratio, 22:15 screen aspect ratio");
                         ui.radio_value(&mut self.config.aspect_ratio, AspectRatio::SquarePixels, "Square pixels")
                             .on_hover_text("1:1 pixel aspect ratio, 8:7 screen aspect ratio");
                         ui.radio_value(&mut self.config.aspect_ratio, AspectRatio::FourThree, "4:3")

--- a/jgnes-native-driver/Cargo.toml
+++ b/jgnes-native-driver/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1.0"
 log = "0.4"
 pollster = "0.3"
 serde = { version = "1", features = ["derive"] }
+thiserror = "1"
 tinyvec = "1"
 
 # This is necessary because the latest published version of rust-sdl2 (0.35.2) uses raw-window-handle 0.4 which is

--- a/jgnes-native-driver/src/config.rs
+++ b/jgnes-native-driver/src/config.rs
@@ -378,6 +378,7 @@ pub struct JgnesDynamicConfig {
     pub overscan: Overscan,
     pub forced_integer_height_scaling: bool,
     pub vsync_mode: VSyncMode,
+    pub pal_black_border: bool,
     pub sync_to_audio: bool,
     pub silence_ultrasonic_triangle_output: bool,
     pub fast_forward_multiplier: u8,
@@ -396,6 +397,7 @@ impl Display for JgnesDynamicConfig {
             self.forced_integer_height_scaling
         )?;
         writeln!(f, "vsync_mode: {}", self.vsync_mode)?;
+        writeln!(f, "pal_black_border: {}", self.pal_black_border)?;
         writeln!(f, "sync_to_audio: {}", self.sync_to_audio)?;
         writeln!(
             f,

--- a/jgnes-native-driver/src/lib.rs
+++ b/jgnes-native-driver/src/lib.rs
@@ -579,9 +579,15 @@ where
 
     let save_state_path = save_state_path.as_ref();
 
-    let (initial_silence_ultrasonic_triangle, initial_ff_multiplier, initial_rewind_buffer_len) = {
+    let (
+        initial_pal_black_border,
+        initial_silence_ultrasonic_triangle,
+        initial_ff_multiplier,
+        initial_rewind_buffer_len,
+    ) = {
         let dynamic_config = dynamic_config.lock().unwrap();
         (
+            dynamic_config.pal_black_border,
             dynamic_config.silence_ultrasonic_triangle_output,
             dynamic_config.fast_forward_multiplier,
             dynamic_config.rewind_buffer_len,
@@ -589,6 +595,7 @@ where
     };
 
     let mut emulator_config = EmulatorConfig {
+        pal_black_border: initial_pal_black_border,
         silence_ultrasonic_triangle_output: initial_silence_ultrasonic_triangle,
     };
 
@@ -635,10 +642,13 @@ where
 
                 let renderer = emulator.get_renderer_mut();
                 renderer.reload_config(dynamic_config)?;
+                emulator_config.pal_black_border = dynamic_config.pal_black_border;
+
                 emulator.get_audio_player_mut().sync_to_audio = dynamic_config.sync_to_audio;
-                input_handler.reload_input_config(&dynamic_config.input_config);
                 emulator_config.silence_ultrasonic_triangle_output =
                     dynamic_config.silence_ultrasonic_triangle_output;
+
+                input_handler.reload_input_config(&dynamic_config.input_config);
 
                 fast_forward_multiplier = dynamic_config.fast_forward_multiplier;
                 rewind_state.reload_buffer_len(dynamic_config.rewind_buffer_len);

--- a/jgnes-native-driver/src/lib.rs
+++ b/jgnes-native-driver/src/lib.rs
@@ -207,6 +207,10 @@ impl AudioPlayer for SdlAudioPlayer {
 
         Ok(())
     }
+
+    fn set_timing_mode(&mut self, timing_mode: TimingMode) {
+        self.downsample_counter.set_timing_mode(timing_mode);
+    }
 }
 
 struct SdlInputPoller {

--- a/jgnes-renderer/Cargo.toml
+++ b/jgnes-renderer/Cargo.toml
@@ -9,9 +9,9 @@ edition = "2021"
 jgnes-proc-macros = { path = "../jgnes-proc-macros" }
 jgnes-core = { path = "../jgnes-core" }
 
-anyhow = "1"
 bytemuck = { version = "1", features = ["derive"] }
 log = "0.4"
 serde = { version = "1", features = ["derive"] }
 raw-window-handle = "0.5"
+thiserror = "1"
 wgpu = "0.16"

--- a/jgnes-renderer/src/config.rs
+++ b/jgnes-renderer/src/config.rs
@@ -36,6 +36,7 @@ impl WgpuBackend {
 pub enum AspectRatio {
     #[default]
     Ntsc,
+    Pal,
     SquarePixels,
     FourThree,
     Stretched,

--- a/jgnes-renderer/src/config.rs
+++ b/jgnes-renderer/src/config.rs
@@ -101,14 +101,12 @@ impl Default for RenderScale {
 }
 
 impl TryFrom<u32> for RenderScale {
-    type Error = anyhow::Error;
+    type Error = String;
 
     fn try_from(value: u32) -> Result<Self, Self::Error> {
         match value {
             1..=16 => Ok(Self(value)),
-            _ => Err(anyhow::Error::msg(format!(
-                "Invalid render scale value: {value}"
-            ))),
+            _ => Err(format!("Invalid render scale value: {value}")),
         }
     }
 }

--- a/jgnes-renderer/src/lib.rs
+++ b/jgnes-renderer/src/lib.rs
@@ -3,6 +3,7 @@ pub mod config;
 mod renderer;
 
 use crate::config::AspectRatio;
+use jgnes_core::TimingMode;
 pub use renderer::WgpuRenderer;
 use std::cmp;
 
@@ -21,6 +22,7 @@ pub fn determine_display_area(
     window_height: u32,
     aspect_ratio: AspectRatio,
     forced_integer_height_scaling: bool,
+    timing_mode: TimingMode,
 ) -> DisplayArea {
     match aspect_ratio {
         AspectRatio::Stretched => DisplayArea {
@@ -29,15 +31,19 @@ pub fn determine_display_area(
             width: window_width,
             height: window_height,
         },
-        AspectRatio::Ntsc | AspectRatio::SquarePixels | AspectRatio::FourThree => {
+        AspectRatio::Ntsc
+        | AspectRatio::Pal
+        | AspectRatio::SquarePixels
+        | AspectRatio::FourThree => {
             let width_to_height_ratio = match aspect_ratio {
                 AspectRatio::Ntsc => 64.0 / 49.0,
+                AspectRatio::Pal => 11.0 / 7.0,
                 AspectRatio::SquarePixels => 8.0 / 7.0,
                 AspectRatio::FourThree => 4.0 / 3.0,
                 AspectRatio::Stretched => unreachable!("nested match expressions"),
             };
 
-            let visible_screen_height = u32::from(jgnes_core::VISIBLE_SCREEN_HEIGHT);
+            let visible_screen_height = timing_mode.visible_screen_height().into();
 
             let width = cmp::min(
                 window_width,

--- a/jgnes-renderer/src/lib.rs
+++ b/jgnes-renderer/src/lib.rs
@@ -37,7 +37,7 @@ pub fn determine_display_area(
         | AspectRatio::FourThree => {
             let width_to_height_ratio = match aspect_ratio {
                 AspectRatio::Ntsc => 64.0 / 49.0,
-                AspectRatio::Pal => 11.0 / 7.0,
+                AspectRatio::Pal => 22.0 / 15.0,
                 AspectRatio::SquarePixels => 8.0 / 7.0,
                 AspectRatio::FourThree => 4.0 / 3.0,
                 AspectRatio::Stretched => unreachable!("nested match expressions"),

--- a/jgnes-web/README.md
+++ b/jgnes-web/README.md
@@ -17,6 +17,11 @@ To install the latest nightly toolchain, including the standard library source (
 rustup toolchain add nightly --component rust-src
 ```
 
+As nightly is unstable, the project (or its dependencies) may not always build on the latest nightly version. To install a specific nightly version (e.g. the 2023-06-01 version):
+```shell
+rustup toolchain add nightly-2023-06-01 --component rust-src
+```
+
 ### wasm-pack
 
 wasm-pack is required to build a WASM/JavaScript package that can run in the browser. It's possible
@@ -40,6 +45,11 @@ wasm-pack build --target web . -- -Z build-std=panic_abort,std
 Alternatively, you can just run the provided `build.sh` script which runs that command:
 ```shell
 ./build.sh
+```
+
+By default `build.sh` will use the toolchain `nightly`. To use a different toolchain, set the `JGNES_WEB_TOOLCHAIN` environment variable:
+```shell
+JGNES_WEB_TOOLCHAIN=nightly-2023-06-01 ./build.sh
 ```
 
 For local testing, the `--dev` flag (passed on to wasm-pack) will disable link-time optimizations and skip running

--- a/jgnes-web/build.sh
+++ b/jgnes-web/build.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-toolchain=${NIGHTLY_TOOLCHAIN:-nightly}
+toolchain=${JGNES_WEB_TOOLCHAIN:-nightly}
 
 RUSTFLAGS=""
 cargo_args=""

--- a/jgnes-web/index.html
+++ b/jgnes-web/index.html
@@ -83,6 +83,9 @@
                     <input type="radio" id="aspect-ntsc" name="aspect-ratio" value="Ntsc" checked>
                     <label for="aspect-ntsc">NTSC</label>
 
+                    <input type="radio" id="aspect-pal" name="aspect-ratio" value="Pal">
+                    <label for="aspect-pal">PAL</label>
+
                     <input type="radio" id="aspect-square-pixels" name="aspect-ratio" value="SquarePixels">
                     <label for="aspect-square-pixels">Square pixels</label>
                 </fieldset>

--- a/jgnes-web/src/config.rs
+++ b/jgnes-web/src/config.rs
@@ -136,6 +136,7 @@ pub struct JgnesWebConfig {
 }
 
 const NTSC: &str = "Ntsc";
+const PAL: &str = "Pal";
 const SQUARE_PIXELS: &str = "SquarePixels";
 
 const NEAREST_NEIGHBOR: &str = "NearestNeighbor";
@@ -181,6 +182,7 @@ impl JgnesWebConfig {
     pub fn set_aspect_ratio(&self, aspect_ratio: &str) {
         let aspect_ratio = match aspect_ratio {
             NTSC => AspectRatio::Ntsc,
+            PAL => AspectRatio::Pal,
             SQUARE_PIXELS => AspectRatio::SquarePixels,
             _ => return,
         };

--- a/jgnes-web/src/lib.rs
+++ b/jgnes-web/src/lib.rs
@@ -12,7 +12,7 @@ use config::JgnesWebConfig;
 use jgnes_core::audio::{DownsampleAction, DownsampleCounter, LowPassFilter};
 use jgnes_core::{
     AudioPlayer, ColorEmphasis, Emulator, EmulatorConfig, InputPoller, JoypadState, Renderer,
-    SaveWriter, TickEffect,
+    SaveWriter, TickEffect, TimingMode,
 };
 use jgnes_renderer::config::{
     AspectRatio, FrameSkip, GpuFilterMode, Overscan, RendererConfig, VSyncMode, WgpuBackend,
@@ -239,6 +239,10 @@ impl AudioPlayer for WebAudioPlayer {
         }
 
         Ok(())
+    }
+
+    fn set_timing_mode(&mut self, timing_mode: TimingMode) {
+        self.downsample_counter.set_timing_mode(timing_mode);
     }
 }
 

--- a/jgnes-web/src/lib.rs
+++ b/jgnes-web/src/lib.rs
@@ -552,6 +552,7 @@ fn run_event_loop(
                         match &mut state.emulator {
                             Some(emulator) => {
                                 let emulator_config = EmulatorConfig {
+                                    pal_black_border: false,
                                     silence_ultrasonic_triangle_output: config
                                         .silence_ultrasonic_triangle_output
                                         .get(),


### PR DESCRIPTION
Implement all changes necessary to vary timing/resolution/etc behaviors based on whether the loaded ROM is meant for NTSC hardware (US/JP) or PAL hardware (EU).

List of differences for PAL compared to NTSC:
* Video signal frequency is ~50.007Hz instead of ~60.1Hz
* PAL TVs typically displayed the full 256x240 pixel frame; NTSC TVs typically displayed at most 256x224, cutting off the top 8 and bottom 8 rows of pixels
  * The PAL NES also puts a small black border around the outside of the frame which cuts off the top scanline, the leftmost two columns, and the rightmost two columns, effectively producing a 252x239 image (added as a new option)
* PAL TVs typically displayed PAL NES output with a pixel aspect ratio of about 11:8, compared to 8:7 for NTSC (added as a new aspect ratio option)
* The CPU clock speed (and thus the audio signal frequency) is ~1.662607MHz, compared to ~1.789772MHz for NTSC
* The PPU runs at 3.2x the CPU speed instead of 3x
* The PPU's vertical blanking period lasts for 70 scanlines instead of 20, making each frame 312 scanlines instead of 262
* The PPU never skips the first cycle of the first visible scanline (NTSC PPU skips that cycle every other frame if rendering is enabled)
* The APU's frame counter is timed to ~50Hz instead of ~60Hz